### PR TITLE
remove hardcoding of programId flag

### DIFF
--- a/src/cloudmanager-helpers.js
+++ b/src/cloudmanager-helpers.js
@@ -296,8 +296,10 @@ function handleError (_error, errorFn) {
   })
 }
 
-function getFormattedFlags (flags) {
-  return Object.keys(flags).filter(flag => flag !== 'programId').map(flag => {
+function getFormattedFlags (flags, Command) {
+  const commonFlagKeys = (Command && Command.flags) ? Object.keys(Command.flags).filter(flag => Command.flags[flag].common) : []
+
+  return Object.keys(flags).filter(flag => !commonFlagKeys.includes(flag)).map(flag => {
     if (flags[flag]) {
       return `--${flag}`
     } else {

--- a/src/commands/cloudmanager/commerce/bin-magento/app/config/dump.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/app/config/dump.js
@@ -27,7 +27,7 @@ class AppConfigDumpCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'app:config:dump',
-        options: ['-n', ...configTypes, ...getFormattedFlags(flags)],
+        options: ['-n', ...configTypes, ...getFormattedFlags(flags, AppConfigDumpCommand)],
       },
       1000, 'app:config:dump')
 

--- a/src/commands/cloudmanager/commerce/bin-magento/app/config/import.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/app/config/import.js
@@ -26,7 +26,7 @@ class AppConfigImportCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'app:config:import',
-        options: ['-n', ...getFormattedFlags(flags)],
+        options: ['-n', ...getFormattedFlags(flags, AppConfigImportCommand)],
       },
       1000, 'app:config:import')
 

--- a/src/commands/cloudmanager/commerce/bin-magento/cache/clean.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/cache/clean.js
@@ -28,7 +28,7 @@ class CacheCleanCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'cache:clean',
-        options: ['-n', ...cacheTypes, ...getFormattedFlags(flags)],
+        options: ['-n', ...cacheTypes, ...getFormattedFlags(flags, CacheCleanCommand)],
       },
       1000, 'cache:clean')
 

--- a/src/commands/cloudmanager/commerce/bin-magento/cache/flush.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/cache/flush.js
@@ -28,7 +28,7 @@ class CacheFlushCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'cache:flush',
-        options: ['-n', ...cacheTypes, ...getFormattedFlags(flags)],
+        options: ['-n', ...cacheTypes, ...getFormattedFlags(flags, CacheFlushCommand)],
       },
       1000, 'cache:flush')
 

--- a/src/commands/cloudmanager/commerce/bin-magento/indexer/reindex.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/indexer/reindex.js
@@ -28,7 +28,7 @@ class IndexerReindexCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'indexer:reindex',
-        options: ['-n', ...indexTypes, ...getFormattedFlags(flags)],
+        options: ['-n', ...indexTypes, ...getFormattedFlags(flags, IndexerReindexCommand)],
       },
       1000, 'indexer:reindex')
 

--- a/src/commands/cloudmanager/commerce/bin-magento/maintenance/disable.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/maintenance/disable.js
@@ -26,7 +26,7 @@ class MaintenanceDisableCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'maintenance:disable',
-        options: [...getFormattedFlags(flags)],
+        options: [...getFormattedFlags(flags, MaintenanceDisableCommand)],
       },
       1000, 'maintenance:disable')
 

--- a/src/commands/cloudmanager/commerce/bin-magento/maintenance/enable.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/maintenance/enable.js
@@ -26,7 +26,7 @@ class MaintenanceEnableCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'maintenance:enable',
-        options: [...getFormattedFlags(flags)],
+        options: [...getFormattedFlags(flags, MaintenanceEnableCommand)],
       },
       1000, 'maintenance:enable')
 

--- a/src/commands/cloudmanager/commerce/bin-magento/maintenance/status.js
+++ b/src/commands/cloudmanager/commerce/bin-magento/maintenance/status.js
@@ -26,7 +26,7 @@ class MaintenanceStatusCommand extends BaseCommerceCliCommand {
       {
         type: 'bin/magento',
         command: 'maintenance:status',
-        options: [...getFormattedFlags(flags)],
+        options: [...getFormattedFlags(flags, MaintenanceStatusCommand)],
       },
       1000, 'maintenance:status')
 

--- a/src/common-commerce-flags.js
+++ b/src/common-commerce-flags.js
@@ -12,12 +12,6 @@ governing permissions and limitations under the License.
 const { flags } = require('@oclif/command')
 
 module.exports = {
-  global: {
-    imsContextName: flags.string({ description: 'the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager' }),
-  },
-  programId: {
-    programId: flags.string({ char: 'p', description: "the programId. if not specified, defaults to 'cloudmanager_programid' config value" }),
-  },
   quiet: {
     quiet: flags.boolean({ char: 'q' }),
   },

--- a/src/common-flags.js
+++ b/src/common-flags.js
@@ -13,13 +13,13 @@ const { flags } = require('@oclif/command')
 
 module.exports = {
   global: {
-    imsContextName: flags.string({ description: 'the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager' }),
+    imsContextName: flags.string({ description: 'the alternate IMS context name to use instead of aio-cli-plugin-cloudmanager', common: true }),
   },
   programId: {
-    programId: flags.string({ char: 'p', description: "the programId. if not specified, defaults to 'cloudmanager_programid' config value" }),
+    programId: flags.string({ char: 'p', description: "the programId. if not specified, defaults to 'cloudmanager_programid' config value", common: true }),
   },
   outputFormat: {
-    json: flags.boolean({ char: 'j', description: 'output in json format', exclusive: ['yaml'] }),
-    yaml: flags.boolean({ char: 'y', description: 'output in yaml format' }),
+    json: flags.boolean({ char: 'j', description: 'output in json format', exclusive: ['yaml'], common: true }),
+    yaml: flags.boolean({ char: 'y', description: 'output in yaml format', common: true }),
   },
 }


### PR DESCRIPTION
@rwalter215 the hardcoding of the `programId` flag is a bit brittle and misses the existing `imsContextName` flag. WDYT about making that dynamic based on the command's actual flags?